### PR TITLE
Fix card back content overlapping card front on reveal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,7 +72,9 @@ body {
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
   transition: transform 0.7s ease-in-out;
+  will-change: transform;
 }
 
 .card-inner.card-flipped {
@@ -85,6 +87,7 @@ body {
   border-radius: 2px;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
+  -webkit-transform: translateZ(0);
 }
 
 .card-back {
@@ -98,7 +101,8 @@ body {
 }
 
 .card-front {
-  transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg) translateZ(0);
+  transform: rotateY(180deg) translateZ(0);
   background-color: #201f1f;
   border: 1px solid rgba(72, 220, 195, 0.2);
   display: flex;


### PR DESCRIPTION
Add will-change: transform and -webkit-transform-style: preserve-3d to
card-inner to force proper GPU compositing. Add translateZ(0) to card
faces so backface-visibility: hidden is respected by webkit browsers,
preventing the card back from bleeding through during and after the flip.

https://claude.ai/code/session_01FHMEnBAXBEvPN3N47G7soP