### PR TITLE
Update card front design: remove stats, color player icon, larger name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @AGENTS.md
+
+## Commands
+
+```bash
+npm run dev        # Start dev server (localhost:3000)
+npm run build      # Production build (static export to /out)
+npm run lint       # ESLint
+npm test           # Jest unit/component tests
+npm run test:e2e   # Playwright end-to-end tests (requires running dev server)
+```
+
+Run a single Jest test file:
+```bash
+npx jest __tests__/randomPicker.test.ts
+```
+
+## Architecture
+
+**Startspieler** is a Terraforming Mars starting player picker — a two-screen Next.js app configured for static export (`output: 'export'`).
+
+### Data flow
+
+Player state lives entirely in `hooks/usePlayerStore.ts`, a custom hook that hydrates from and persists to `localStorage` (key: `startspieler_players`). There is no server state or API. Both pages consume this hook directly — there is no global context or state manager.
+
+`lib/randomPicker.ts` defines the core types (`Player`, `TmColor`) and the `pickRandom` utility. `TM_COLORS` maps the five Terraforming Mars player colors (`red`, `green`, `blue`, `yellow`, `black`) to hex values used throughout the UI.
+
+### Pages
+
+- `/` (`app/page.tsx`) — main picker screen. Calls `pickRandom(selectedPlayers)` on button click, then passes the winner to `CardFlipReveal`.
+- `/settings` (`app/settings/page.tsx`) — player management (add, rename, delete, assign color, toggle selected).
+
+### Card reveal
+
+`components/CardFlipReveal.tsx` orchestrates the flip: it sets `displayedWinner` immediately (so the front face is pre-populated), then waits 300 ms before setting `flipped = true` to trigger the CSS 3D flip animation. `components/PlayerCard.tsx` renders both faces of the card. `components/TmColorPicker.tsx` renders the color swatches in settings.
+
+### Styling
+
+Tailwind v4 with a fully custom design token palette defined in `app/globals.css` under `@theme`. The dark sci-fi aesthetic uses `--color-primary` (amber) for CTA elements and `--color-secondary` (cyan `#48dcc3`) for active/selected states. Card flip 3D is done with plain CSS classes (`.card-scene`, `.card-inner`, `.card-face`, `.card-front`, `.card-back`) in `globals.css` — the front face starts at `rotateY(180deg)` and becomes visible when `.card-flipped` rotates the inner container 180°.
+
+Fonts: Space Grotesk (`font-headline`, `font-label`) and Manrope (`font-body`), loaded via `next/font/google`. Icons: Material Symbols Outlined loaded from Google Fonts CDN.
+
+### Testing
+
+- Unit tests (`__tests__/`) use Jest + jsdom + React Testing Library. Configured in `jest.config.js` via `next/jest`; e2e tests are excluded from Jest runs.
+- E2E tests (`e2e/`) use Playwright against the running dev server.

--- a/components/PlayerCard.tsx
+++ b/components/PlayerCard.tsx
@@ -71,8 +71,8 @@ export function PlayerCard({ player, flipped, isWinner }: PlayerCardProps) {
               <div className="w-16 h-16 rounded-full border-2 border-secondary p-1">
                 <div className="w-full h-full rounded-full bg-secondary/20 flex items-center justify-center">
                   <span
-                    className="material-symbols-outlined text-secondary"
-                    style={{ fontSize: '32px', fontVariationSettings: "'FILL' 1" }}
+                    className="material-symbols-outlined"
+                    style={{ fontSize: '32px', fontVariationSettings: "'FILL' 1", color: TM_COLORS[player.color] }}
                   >
                     person
                   </span>
@@ -86,7 +86,7 @@ export function PlayerCard({ player, flipped, isWinner }: PlayerCardProps) {
             </div>
 
             {/* Name */}
-            <h2 className="font-headline text-xl font-extrabold text-on-surface tracking-tight text-center leading-tight">
+            <h2 className="font-headline text-2xl font-extrabold text-on-surface tracking-tight text-center leading-tight">
               {player.name}
             </h2>
 
@@ -102,20 +102,6 @@ export function PlayerCard({ player, flipped, isWinner }: PlayerCardProps) {
               <span className="font-label text-[9px] font-bold text-secondary tracking-widest">
                 COLOR: {colorName}
               </span>
-            </div>
-
-            {/* Stats grid */}
-            <div className="w-full grid grid-cols-3 gap-1.5">
-              {[
-                ['Agility', '88'],
-                ['Tactics', '94'],
-                ['Focus', '72'],
-              ].map(([label, val]) => (
-                <div key={label} className="bg-surface-container-high p-2 text-center">
-                  <p className="font-label text-[8px] opacity-50 uppercase mb-0.5">{label}</p>
-                  <p className="font-headline text-sm font-bold text-primary">{val}%</p>
-                </div>
-              ))}
             </div>
 
             {/* Progress bar */}


### PR DESCRIPTION
- Remove agility/tactics/focus stat boxes from revealed card front
- Player head icon now uses the player's team color for distinction
- Player name font size increased from text-xl to text-2xl

https://claude.ai/code/session_01KG8NGYHwhtcvaMb8PWKQXJ